### PR TITLE
Delete wrong information in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ based on the [flappy-bird-gym](https://github.com/Talendar/flappy-bird-gym) proj
 ## State space
 
 The "FlappyBird-v0" environment, yields simple numerical information about the game's state as
-observations or RGB-arrays (images) representing the game's screen.
+observations representing the game's screen.
 
 ### `FlappyBird-v0`
+There exist two options for the observations:  
 1. option
 * The LIDAR sensor 180 readings (Paper: [Playing Flappy Bird Based on Motion Recognition Using a Transformer Model and LIDAR Sensor](https://www.mdpi.com/1424-8220/24/6/1905))
 
@@ -31,9 +32,6 @@ observations or RGB-arrays (images) representing the game's screen.
 * player's vertical position
 * player's vertical velocity
 * player's rotation
-
-3. option
-* or RGB-array (image) representing the game's screen
 
 ## Action space
 


### PR DESCRIPTION
Hi, 
It seems,from my understanding of the code, that the RGB option is not available. Therefore I corrected the README

We can clearly see it in the __init__

https://github.com/markub3327/flappy-bird-gymnasium/blob/f56c21b47b90a1939ea32c6e40478be3c2809b14/flappy_bird_gymnasium/envs/flappy_bird_env.py#L117-L134

And 
https://github.com/markub3327/flappy-bird-gymnasium/blob/f56c21b47b90a1939ea32c6e40478be3c2809b14/flappy_bird_gymnasium/envs/flappy_bird_env.py#L152-L156

The observations are either lidar or features (pipes)